### PR TITLE
Actually support printing on different paper sizes, and make them pre-selectable on the server

### DIFF
--- a/frontend/src/app/canvas-page/canvas-page.component.html
+++ b/frontend/src/app/canvas-page/canvas-page.component.html
@@ -23,7 +23,7 @@
         </p-button>
     </p-overlayPanel>
 
-    <p-button (click)="sizesPanel.toggle($event)">
+    <p-button (click)="sizesPanel.toggle($event)" [disabled]="paperSizeConfigured">
         {{ paperSize.width }} × {{ paperSize.height }} mm [{{ paperSize.shape }}]
     </p-button>
 </div>

--- a/frontend/src/app/canvas-page/canvas-page.component.ts
+++ b/frontend/src/app/canvas-page/canvas-page.component.ts
@@ -173,6 +173,8 @@ export class CanvasPageComponent implements AfterViewInit {
         try {
             const fd = new FormData();
             fd.append('image', await this.getBlob());
+            fd.append('width', String(this.width));
+            fd.append('height', String(this.height));
             const response = await firstValueFrom(this.httpClient.post('/print', fd));
             this.messageService.add({severity: 'success', summary: 'Success', detail: 'enjoy your label'});
         } catch (e) {

--- a/frontend/src/app/canvas-page/canvas-page.component.ts
+++ b/frontend/src/app/canvas-page/canvas-page.component.ts
@@ -41,6 +41,7 @@ const getPx = (mm: number, dpi: number) => {
 export class CanvasPageComponent implements AfterViewInit {
     @ViewChild('canvasElement') canvas?: ElementRef<HTMLCanvasElement>;
     public busy = false;
+    public paperSizeConfigured = false;
     public fabric?: fabric.Canvas;
     public ctx?: CanvasRenderingContext2D;
     public form: FormGroup;
@@ -94,7 +95,7 @@ export class CanvasPageComponent implements AfterViewInit {
         this.paperSize = SIZES[0];
     }
 
-    public ngAfterViewInit() {
+    public async ngAfterViewInit() {
         if (this.canvas) {
             this.fabric = new fabric.Canvas('canvas', {
                 backgroundColor: '#fff',
@@ -120,6 +121,12 @@ export class CanvasPageComponent implements AfterViewInit {
                 this.fabric.freeDrawingBrush.width = values.brushSize;
             }
         });
+
+        try {
+            const response = await firstValueFrom(this.httpClient.get<number>('/papersize'));
+            this.paperSize = SIZES[response];
+            this.paperSizeConfigured = true;
+        } finally {}
     }
 
     public createText() {

--- a/phomeme/__init__.py
+++ b/phomeme/__init__.py
@@ -37,7 +37,7 @@ def handle_image():
         return f"Error loading image: {e}", 500
 
     try:
-        print_image = PrintImage(img)
+        print_image = PrintImage(img, offset=True, resize=False)
         print_image.print()
     except Exception as e:
         print(e)
@@ -69,8 +69,12 @@ class PrintImage:
         self.image = img
 
     def _offset(self):
-        imgborder = Image.new("1", (384, 240), color=1)
-        imgborder.paste(self.image, (61, 0))
+        # For some reason, the printer rejects widths > 384px, even though it
+        # should be able to print 50mm*8px/mm=400px...
+        target_width, target_height = 384, max(240, self.image.height)
+        imgborder = Image.new("1", (target_width, target_height), color=1)
+        horizontal_offset = target_width - self.image.width
+        imgborder.paste(self.image, (horizontal_offset, 0))
         self.image = imgborder
 
     def _print(self):

--- a/phomeme/__init__.py
+++ b/phomeme/__init__.py
@@ -40,13 +40,18 @@ def paper_size():
 def handle_image():
     try:
         f = request.files["image"]
+        file_length = f.seek(0, os.SEEK_END)
+        f.seek(0, os.SEEK_SET)
+        width = int(float(request.form.get("width")))
+        height = int(float(request.form.get("height")))
+        print('Received image with length %d bytes and intended print size %dx%d' % (file_length, width, height))
         img = Image.open(f)
     except Exception as e:
         print(e)
         return f"Error loading image: {e}", 500
 
     try:
-        print_image = PrintImage(img, offset=True, resize=False)
+        print_image = PrintImage(img, offset=True, resize=(width, height))
         print_image.print()
     except Exception as e:
         print(e)
@@ -58,29 +63,37 @@ def handle_image():
 class PrintImage:
     image: Image
 
-    def __init__(self, image: Image, offset=True, resize=True):
+    def __init__(self, image: Image, offset=True, resize=(323, 240)):
         self.image = image
+        print('Original image size:', image.size)
         if resize:
-            self._resize()
+            self._resize(resize[0], resize[1])
+            print('Image size after resize:', self.image.size)
         if offset:
             self._offset()
+            print('Image size after offset:', self.image.size)
 
-    def _resize(self):
+    def _resize(self, target_width, target_height):
         img = self.image
 
         if img.height > img.width:
             img = img.transpose(Image.ROTATE_90)
-        if 323 / img.width * img.height <= 240:
-            img = img.resize(size=(323, int(323 / img.width * img.height)))
+
+        if img.width / target_width > img.height / target_height:
+            # target_width is bigger dimension -> keep it
+            target_height = int(img.height * (target_width / img.width))
         else:
-            img = img.resize(size=(int(240 / img.height * img.width), 240))
+            # target_height is bigger dimension -> keep it
+            target_width = int(img.width * (target_height / img.height))
+
+        img = img.resize(size=(target_width, target_height))
 
         self.image = img
 
     def _offset(self):
         # For some reason, the printer rejects widths > 384px, even though it
         # should be able to print 50mm*8px/mm=400px...
-        target_width, target_height = 384, max(240, self.image.height)
+        target_width, target_height = 384, self.image.height
         imgborder = Image.new("1", (target_width, target_height), color=1)
         horizontal_offset = target_width - self.image.width
         imgborder.paste(self.image, (horizontal_offset, 0))

--- a/phomeme/__init__.py
+++ b/phomeme/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask, request, make_response, redirect, jsonify
 from flask_cors import CORS
 
 DEVICE = os.environ["PHOMEMO_BT_MAC"]
+PAPER_SIZE = os.environ.get("PHOMEMO_PAPER_SIZE", None)
 
 
 app = Flask(__name__)
@@ -25,6 +26,14 @@ def index():
 @app.route("/<path:static>")
 def static_helper(static):
     return app.send_static_file(static)
+
+
+@app.route("/papersize")
+def paper_size():
+    if PAPER_SIZE:
+        return jsonify(PAPER_SIZE)
+    else:
+        return "No default paper size configured", 404
 
 
 @app.route("/print", methods=["POST"])


### PR DESCRIPTION
This PR adjusts the backend to correctly print non-default label sizes (= anything that's not 40×30mm), and adds an environment variable `PHOMEMO_PAPER_SIZE` to force the web frontend to use a specific label size (so users can't choose an incorrect size that isn't actually loaded in the printer).

Usage example:

    # pre-select label size "6" (= 50x50 circular)
    docker run -e PHOMEMO_BT_MAC=ab:cd:ef:12:34:56 -e PHOMEMO_PAPER_SIZE=6 --net=host -it phomemer