### PR TITLE
Add USB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You can pass this character device into the Docker container and omit the
 `PHOMEMO_BT_MAC` setting to make phomemer use the USB connection.
 (`PHOMEMO_BT_MAC` takes precedence over USB if it is specified!).
 
+This requires that the Docker user has sufficient permission to write to
+`/dev/usb/lp0` — assign the correct group membership or modify the character
+device's permissions through a udev rule if not.
+
 `--net=host` is still required here to allow you/your users to access phomemer
 through a well-known port on the Docker host's localhost.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ access bluetooth devices. Sadly, this will most likely only work under linux.
 docker run -e PHOMEMO_BT_MAC=<your-printers-mac> --net=host -it ghcr.io/b4ckspace/phomemer
 ```
 
+### USB connection
+
+Instead of Bluetooth, you can also connect to your printer via USB.  
+This should create a character device at `/dev/usb/lp0` (or a higher number).
+You can pass this character device into the Docker container and omit the
+`PHOMEMO_BT_MAC` setting to make phomemer use the USB connection.
+(`PHOMEMO_BT_MAC` takes precedence over USB if it is specified!).
+
+`--net=host` is still required here to allow you/your users to access phomemer
+through a well-known port on the Docker host's localhost.
+
+```
+docker run --device '/dev/usb/lp0:/dev/phomemo' --net=host -it ghcr.io/b4ckspace/phomemer
+```
+
 ## Docker compose
 
 1. Copy .env.dist to .env and enter your printer address, with colons

--- a/phomeme/__init__.py
+++ b/phomeme/__init__.py
@@ -1,13 +1,18 @@
 from io import BytesIO
 from multiprocessing import Lock
 import os
+import pathlib
 import socket
 
 from PIL import Image, ImageDraw, ImageFont
 from flask import Flask, request, make_response, redirect, jsonify
 from flask_cors import CORS
 
-DEVICE = os.environ["PHOMEMO_BT_MAC"]
+DEVICE = os.environ.get("PHOMEMO_BT_MAC", None)
+if not DEVICE:
+    CHARDEV = '/dev/phomemo'
+    if not pathlib.Path(CHARDEV).is_char_device():
+        raise Exception('No valid printer target configured (envvar PHOMEMO_BT_MAC unset and %s is not a character device)' % CHARDEV)
 
 
 app = Flask(__name__)
@@ -97,14 +102,18 @@ class PrintImage:
         buf += ibuf
 
         # -- send
-        sock = socket.socket(
-            socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM
-        )
-        sock.bind((socket.BDADDR_ANY, 1))
-        sock.connect((DEVICE, 1))
-        sock.sendall(bytes(buf))
-        sock.recv(1024)
-        sock.close()
+        if DEVICE:
+            sock = socket.socket(
+                socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM
+            )
+            sock.bind((socket.BDADDR_ANY, 1))
+            sock.connect((DEVICE, 1))
+            sock.sendall(bytes(buf))
+            sock.recv(1024)
+            sock.close()
+        else:
+            with open(CHARDEV, 'wb') as f:
+                f.write(bytes(buf))
 
     def print(self):
         with app.printlock:


### PR DESCRIPTION
Instead of Bluetooth, you can also connect to your printer via USB. 
Use `--device '/dev/usb/lp0:/dev/phomemo'` when running the Docker container. This requires that the Docker user has sufficient permission to write to `/dev/usb/lp0` — assign the correct group membership or modify the character device's permissions through a udev rule if not.